### PR TITLE
harden initialize() lifetime bound and expiredPurchasePrice floor

### DIFF
--- a/contracts/MintingHubV3/MintingHub.sol
+++ b/contracts/MintingHubV3/MintingHub.sol
@@ -38,6 +38,15 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
     uint256 public constant CHALLENGER_REWARD = 20000; // 2%
     uint256 public constant EXPIRED_PRICE_FACTOR = 10;
 
+    /**
+     * @notice Lower bound (floor) of the `expiredPurchasePrice` decay path, expressed in
+     * parts per million of the position's liquidation price. The force-sale price never
+     * falls below `liqprice * EXPIRED_PRICE_FLOOR_PPM / 1_000_000`. This caps the maximum
+     * loss the equity reserve can absorb per cycle when no competing searcher bids on the
+     * decay path.
+     */
+    uint32 public constant EXPIRED_PRICE_FLOOR_PPM = 300_000; // 30% of liqprice
+
     IPositionFactory private immutable POSITION_FACTORY; // position contract to clone
 
     IDecentralizedEURO public immutable DEURO; // currency
@@ -90,9 +99,13 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
         _;
     }
 
-    constructor(address _deur, uint24 _initialRatePPM, address payable _roller, address _factory, address _weth)
-        Leadrate(IReserve(IDecentralizedEURO(_deur).reserve()), _initialRatePPM)
-    {
+    constructor(
+        address _deur,
+        uint24 _initialRatePPM,
+        address payable _roller,
+        address _factory,
+        address _weth
+    ) Leadrate(IReserve(IDecentralizedEURO(_deur).reserve()), _initialRatePPM) {
         DEURO = IDecentralizedEURO(_deur);
         POSITION_FACTORY = IPositionFactory(_factory);
         WETH = _weth;
@@ -271,7 +284,12 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
      *                                  (automatically reduced to the available amount)
      * @param postponeCollateralReturn  To postpone the return of the collateral to the challenger. Usually false.
      */
-    function bid(uint256 _challengeNumber, uint256 size, bool postponeCollateralReturn, bool returnCollateralAsNative) external {
+    function bid(
+        uint256 _challengeNumber,
+        uint256 size,
+        bool postponeCollateralReturn,
+        bool returnCollateralAsNative
+    ) external {
         _bid(_challengeNumber, size, postponeCollateralReturn, returnCollateralAsNative);
     }
 
@@ -282,7 +300,12 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
         _bid(_challengeNumber, size, postponeCollateralReturn, false);
     }
 
-    function _bid(uint256 _challengeNumber, uint256 size, bool postponeCollateralReturn, bool returnCollateralAsNative) internal {
+    function _bid(
+        uint256 _challengeNumber,
+        uint256 size,
+        bool postponeCollateralReturn,
+        bool returnCollateralAsNative
+    ) internal {
         Challenge memory _challenge = challenges[_challengeNumber];
         (uint256 liqPrice, uint40 phase) = _challenge.position.challengeData();
         size = _challenge.size < size ? _challenge.size : size; // cannot bid for more than the size of the challenge
@@ -291,8 +314,18 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
             _avertChallenge(_challenge, _challengeNumber, liqPrice, size, returnCollateralAsNative);
             emit ChallengeAverted(address(_challenge.position), _challengeNumber, size);
         } else {
-            _returnChallengerCollateral(_challenge, _challengeNumber, size, postponeCollateralReturn, returnCollateralAsNative);
-            (uint256 transferredCollateral, uint256 offer) = _finishChallenge(_challenge, size, returnCollateralAsNative);
+            _returnChallengerCollateral(
+                _challenge,
+                _challengeNumber,
+                size,
+                postponeCollateralReturn,
+                returnCollateralAsNative
+            );
+            (uint256 transferredCollateral, uint256 offer) = _finishChallenge(
+                _challenge,
+                size,
+                returnCollateralAsNative
+            );
             emit ChallengeSucceeded(address(_challenge.position), _challengeNumber, offer, transferredCollateral, size);
         }
     }
@@ -338,7 +371,13 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
         return (collateral, offer);
     }
 
-    function _avertChallenge(Challenge memory _challenge, uint256 number, uint256 liqPrice, uint256 size, bool asNative) internal {
+    function _avertChallenge(
+        Challenge memory _challenge,
+        uint256 number,
+        uint256 liqPrice,
+        uint256 size,
+        bool asNative
+    ) internal {
         require(block.timestamp != _challenge.start); // do not allow to avert the challenge in the same transaction, see CS-ZCHF-037
         if (msg.sender == _challenge.challenger) {
             // allow challenger to cancel challenge without paying themselves
@@ -448,7 +487,13 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
         }
     }
 
-    function _returnCollateral(IERC20 collateral, address recipient, uint256 amount, bool postpone, bool asNative) internal {
+    function _returnCollateral(
+        IERC20 collateral,
+        address recipient,
+        uint256 amount,
+        bool postpone,
+        bool asNative
+    ) internal {
         if (postpone) {
             // Postponing helps in case the challenger was blacklisted or otherwise cannot receive at the moment.
             pendingReturns[address(collateral)][recipient] += amount;
@@ -467,7 +512,12 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
      *
      * The price starts at 10x the liquidation price at the expiration time, linearly declines to
      * 1x liquidation price over the course of one challenge period, and then linearly declines
-     * less steeply to 0 over the course of another challenge period.
+     * less steeply to `EXPIRED_PRICE_FLOOR_PPM` of the liquidation price over the course of
+     * another challenge period. After both phases the price stays at the floor permanently.
+     *
+     * The floor caps the equity-reserve loss per force-sale cycle at the asymmetric portion of
+     * the position's principal (typically ~70%). Without it, the decay continues to zero and a
+     * caller who controls the position's expiration can drain the reserve unchecked.
      */
     function expiredPurchasePrice(IPosition pos) public view returns (uint256) {
         uint256 liqprice = pos.virtualPrice();
@@ -477,17 +527,19 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
         } else {
             uint256 challengePeriod = pos.challengePeriod();
             uint256 timePassed = block.timestamp - expiration;
+            uint256 floorPrice = (liqprice * EXPIRED_PRICE_FLOOR_PPM) / 1_000_000;
             if (timePassed <= challengePeriod) {
                 // from 10x liquidation price to 1x in first phase
                 uint256 timeLeft = challengePeriod - timePassed;
                 return liqprice + (((EXPIRED_PRICE_FACTOR - 1) * liqprice * timeLeft) / challengePeriod);
             } else if (timePassed < 2 * challengePeriod) {
-                // from 1x liquidation price to 0 in second phase
+                // from 1x liquidation price down to floorPrice in second phase
+                uint256 spread = liqprice - floorPrice;
                 uint256 timeLeft = 2 * challengePeriod - timePassed;
-                return (liqprice * timeLeft) / challengePeriod;
+                return floorPrice + (spread * timeLeft) / challengePeriod;
             } else {
-                // get collateral for free after both phases passed
-                return 0;
+                // permanent floor after both phases passed
+                return floorPrice;
             }
         }
     }
@@ -499,7 +551,11 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
      * To prevent dust either the remaining collateral needs to be bought or collateral with a value
      * of at least OPENING_FEE (1000 dEURO) needs to remain in the position for a different buyer
      */
-    function buyExpiredCollateral(IPosition pos, uint256 upToAmount, bool receiveAsNative) external validPos(address(pos)) returns (uint256) {
+    function buyExpiredCollateral(
+        IPosition pos,
+        uint256 upToAmount,
+        bool receiveAsNative
+    ) external validPos(address(pos)) returns (uint256) {
         return _buyExpiredCollateral(pos, upToAmount, receiveAsNative);
     }
 
@@ -540,15 +596,12 @@ contract MintingHub is IMintingHub, ERC165, Leadrate {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view override virtual returns (bool) {
-        return
-            interfaceId == type(IMintingHub).interfaceId ||
-            super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IMintingHub).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /**
      * @dev Required for WETH.withdraw() callbacks.
      */
     receive() external payable {}
-
 }

--- a/contracts/MintingHubV3/Position.sol
+++ b/contracts/MintingHubV3/Position.sol
@@ -222,10 +222,16 @@ contract Position is Ownable, IPosition, MathUtil {
     /**
      * Initialization method for clones.
      * Can only be called once. Should be called immediately after creating the clone.
+     *
+     * The clone must have a minimum economic lifetime of at least `2 * challengePeriod`.
+     * Without this lower bound a caller could open a clone with `block.timestamp + 1` as
+     * expiration, immediately mint, wait out the decay window, and force-sale the same
+     * collateral back at the decay floor — a drain vector on the equity reserve.
      */
     function initialize(address parent, uint40 _expiration) external onlyHub {
         if (expiration != 0) revert AlreadyInitialized();
-        if (_expiration < block.timestamp || _expiration > Position(original).expiration()) revert InvalidExpiration(); // expiration must not be later than original
+        if (_expiration > Position(original).expiration()) revert InvalidExpiration(); // expiration must not be later than original
+        if (_expiration < block.timestamp + 2 * uint256(challengePeriod)) revert InvalidExpiration();
         expiration = _expiration;
         price = Position(payable(parent)).price();
         _fixRateToLeadrate(Position(payable(parent)).riskPremiumPPM());
@@ -332,7 +338,12 @@ contract Position is Ownable, IPosition, MathUtil {
      * @notice "All in one" function to adjust the principal, the collateral amount,
      * and the price in one transaction.
      */
-    function adjust(uint256 newPrincipal, uint256 newCollateral, uint256 newPrice, bool withdrawAsNative) external payable onlyOwner {
+    function adjust(
+        uint256 newPrincipal,
+        uint256 newCollateral,
+        uint256 newPrice,
+        bool withdrawAsNative
+    ) external payable onlyOwner {
         _adjust(newPrincipal, newCollateral, newPrice, address(0), withdrawAsNative);
     }
 
@@ -358,11 +369,23 @@ contract Position is Ownable, IPosition, MathUtil {
     /**
      * @notice "All in one" function with reference position support.
      */
-    function adjustWithReference(uint256 newPrincipal, uint256 newCollateral, uint256 newPrice, address referencePosition, bool withdrawAsNative) external payable onlyOwner {
+    function adjustWithReference(
+        uint256 newPrincipal,
+        uint256 newCollateral,
+        uint256 newPrice,
+        address referencePosition,
+        bool withdrawAsNative
+    ) external payable onlyOwner {
         _adjust(newPrincipal, newCollateral, newPrice, referencePosition, withdrawAsNative);
     }
 
-    function _adjust(uint256 newPrincipal, uint256 newCollateral, uint256 newPrice, address referencePosition, bool withdrawAsNative) internal {
+    function _adjust(
+        uint256 newPrincipal,
+        uint256 newCollateral,
+        uint256 newPrice,
+        address referencePosition,
+        bool withdrawAsNative
+    ) internal {
         if (msg.value > 0) {
             if (address(collateral) != IMintingHub(hub).WETH()) revert NativeOnlyForWETH();
             IWrappedNative(address(collateral)).deposit{value: msg.value}();
@@ -477,7 +500,7 @@ contract Position is Ownable, IPosition, MathUtil {
 
     /**
      * @notice Computes the virtual price of the collateral in dEURO, which is the minimum collateral
-     * price required to cover the entire debt with interest overcollateralization, lower bounded by the floor price. 
+     * price required to cover the entire debt with interest overcollateralization, lower bounded by the floor price.
      * Returns the challenged price if a challenge is active.
      * @param colBalance The collateral balance of the position.
      * @param floorPrice The minimum price of the collateral in dEURO.
@@ -485,9 +508,9 @@ contract Position is Ownable, IPosition, MathUtil {
     function _virtualPrice(uint256 colBalance, uint256 floorPrice) internal view returns (uint256) {
         if (challengedAmount > 0) return challengedPrice;
         if (colBalance == 0) return floorPrice;
-        
+
         uint256 virtPrice = (_getCollateralRequirement() * ONE_DEC18) / colBalance;
-        return virtPrice < floorPrice ? floorPrice: virtPrice;
+        return virtPrice < floorPrice ? floorPrice : virtPrice;
     }
 
     /**
@@ -525,7 +548,9 @@ contract Position is Ownable, IPosition, MathUtil {
 
         if (timestamp > lastAccrual && principal > 0) {
             uint256 delta = timestamp - lastAccrual;
-            newInterest += (principal * (1_000_000 - reserveContribution) * fixedAnnualRatePPM * delta) / (365 days * 1_000_000 * 1_000_000);
+            newInterest +=
+                (principal * (1_000_000 - reserveContribution) * fixedAnnualRatePPM * delta) /
+                (365 days * 1_000_000 * 1_000_000);
         }
 
         return newInterest;
@@ -554,7 +579,7 @@ contract Position is Ownable, IPosition, MathUtil {
     function getDebt() public view returns (uint256) {
         return _getDebt();
     }
-    
+
     /**
      * @notice Public function to calculate current debt with overcollateralized interest
      * @return The total debt including overcollateralized interest
@@ -732,7 +757,10 @@ contract Position is Ownable, IPosition, MathUtil {
         _emitUpdate(balance, price, principal);
     }
 
-    function _withdrawCollateralAsNative(address target, uint256 amount) internal noCooldown noChallenge returns (uint256) {
+    function _withdrawCollateralAsNative(
+        address target,
+        uint256 amount
+    ) internal noCooldown noChallenge returns (uint256) {
         if (amount > 0) {
             IWrappedNative(address(collateral)).withdraw(amount);
             (bool success, ) = target.call{value: amount}("");
@@ -772,7 +800,7 @@ contract Position is Ownable, IPosition, MathUtil {
     function _checkCollateral(uint256 collateralReserve, uint256 atPrice) internal view {
         uint256 relevantCollateral = collateralReserve < minimumCollateral ? 0 : collateralReserve;
         uint256 collateralRequirement = _getCollateralRequirement();
-        
+
         if (relevantCollateral * atPrice < collateralRequirement * ONE_DEC18) {
             revert InsufficientCollateral(relevantCollateral * atPrice, collateralRequirement * ONE_DEC18);
         }

--- a/test/unit/ForceSaleTests.ts
+++ b/test/unit/ForceSaleTests.ts
@@ -152,11 +152,33 @@ describe("ForceSale Tests", () => {
       expect(eP2).to.be.lessThanOrEqual(p);
     });
 
-    it("expect 0 price after 2nd period", async () => {
+    it("expect floor price after 2nd period", async () => {
       const period = await position.challengePeriod();
       await evm_increaseTime(103n * 86_400n + 2n * period); // post 2nd period
       const eP3 = await mintingHub.expiredPurchasePrice(position);
-      expect(eP3).to.be.equal(0n);
+      const liq = await position.virtualPrice();
+      const floorPpm = await mintingHub.EXPIRED_PRICE_FLOOR_PPM();
+      const expected = (liq * BigInt(floorPpm)) / 1_000_000n;
+      expect(eP3).to.be.equal(expected);
+    });
+
+    it("decay never falls below floor in 2nd phase", async () => {
+      const period = await position.challengePeriod();
+      const liq = await position.virtualPrice();
+      const floorPpm = await mintingHub.EXPIRED_PRICE_FLOOR_PPM();
+      const floorPrice = (liq * BigInt(floorPpm)) / 1_000_000n;
+
+      // jump to the start of phase 2 (expiration + challengePeriod)
+      const phase2Start = (await position.expiration()) + period + 1n;
+      await evm_increaseTimeTo(phase2Start);
+
+      // sample five points across phase 2 and confirm each stays within [floor, 1x liq]
+      for (let i = 0; i < 5; i++) {
+        await evm_increaseTime(period / 5n);
+        const ePi = await mintingHub.expiredPurchasePrice(position);
+        expect(ePi).to.be.greaterThanOrEqual(floorPrice);
+        expect(ePi).to.be.lessThanOrEqual(liq);
+      }
     });
   });
 
@@ -428,6 +450,95 @@ describe("ForceSale Tests", () => {
       await dEURO.approve(positionContract.getAddress(), floatToDec18(1_000_000));
       await mintingHub.buyExpiredCollateral(positionContract, fInitialCollateral);
       expect(await position.getDebt()).to.be.equal(0n);
+    });
+  });
+
+  describe("clone minimum lifetime", () => {
+    // The clone-with-short-expiration vector that was exploited in TX
+    // 0x1accee7d... on 2026-04-25. A clone must have at least 2 * challengePeriod
+    // of remaining lifetime; otherwise the caller can mint, wait for full decay,
+    // and force-sale the same collateral back to themselves cheaply.
+    beforeEach(async () => {
+      // make sure the parent position is past its cooldown so cloning is allowed
+      await evm_increaseTimeTo((await position.cooldown()) + 60n);
+    });
+
+    const cloneSig =
+      "clone(address,address,uint256,uint256,uint40,uint256)" as const;
+
+    it("rejects clone with expiration in the past", async () => {
+      const now = BigInt((await getTimeStamp()) ?? 0);
+      await coin.connect(alice).approve(mintingHub.getAddress(), floatToDec18(1));
+      const tx = (mintingHub.connect(alice) as any)[cloneSig](
+        alice.address,
+        await position.getAddress(),
+        floatToDec18(1),
+        floatToDec18(100),
+        now - 1n,
+        0,
+      );
+      await expect(tx).to.be.revertedWithCustomError(position, "InvalidExpiration");
+    });
+
+    it("rejects clone with lifetime below 2 * challengePeriod", async () => {
+      const cp = await position.challengePeriod();
+      const now = BigInt((await getTimeStamp()) ?? 0);
+      const tooShort = now + 2n * cp - 60n; // one minute short of the minimum
+      await coin.connect(alice).approve(mintingHub.getAddress(), floatToDec18(1));
+      const tx = (mintingHub.connect(alice) as any)[cloneSig](
+        alice.address,
+        await position.getAddress(),
+        floatToDec18(1),
+        floatToDec18(100),
+        tooShort,
+        0,
+      );
+      await expect(tx).to.be.revertedWithCustomError(position, "InvalidExpiration");
+    });
+
+    it("rejects the 36-second clone replicating the 2026-04-25 exploit", async () => {
+      const now = BigInt((await getTimeStamp()) ?? 0);
+      await coin.connect(alice).approve(mintingHub.getAddress(), floatToDec18(1));
+      const tx = (mintingHub.connect(alice) as any)[cloneSig](
+        alice.address,
+        await position.getAddress(),
+        floatToDec18(1),
+        floatToDec18(100),
+        now + 36n,
+        0,
+      );
+      await expect(tx).to.be.revertedWithCustomError(position, "InvalidExpiration");
+    });
+
+    it("accepts clone with lifetime exactly at the minimum", async () => {
+      const cp = await position.challengePeriod();
+      const now = BigInt((await getTimeStamp()) ?? 0);
+      const minOk = now + 2n * cp + 5n; // five-second buffer for the next block timestamp
+      await coin.connect(alice).approve(mintingHub.getAddress(), floatToDec18(1));
+      const tx = await (mintingHub.connect(alice) as any)[cloneSig](
+        alice.address,
+        await position.getAddress(),
+        floatToDec18(1),
+        floatToDec18(100),
+        minOk,
+        0,
+      );
+      const receipt = await tx.wait();
+      expect(receipt?.status).to.equal(1);
+    });
+
+    it("still rejects clone with expiration after the parent's expiration", async () => {
+      const parentExp = await position.expiration();
+      await coin.connect(alice).approve(mintingHub.getAddress(), floatToDec18(1));
+      const tx = (mintingHub.connect(alice) as any)[cloneSig](
+        alice.address,
+        await position.getAddress(),
+        floatToDec18(1),
+        floatToDec18(100),
+        parentExp + 1n,
+        0,
+      );
+      await expect(tx).to.be.revertedWithCustomError(position, "InvalidExpiration");
     });
   });
 });

--- a/test/unit/NativeChallengeTests.ts
+++ b/test/unit/NativeChallengeTests.ts
@@ -84,7 +84,7 @@ describe("Native Challenge Tests", () => {
     // Bootstrap dEURO
     const testTokenFactory = await ethers.getContractFactory("TestToken");
     mockXEUR = await testTokenFactory.deploy("CryptoFranc", "XEUR", 18);
-    const limit = floatToDec18(1_000_000);
+    const limit = floatToDec18(5_000_000);
     const bridgeFactory = await ethers.getContractFactory("StablecoinBridge");
     bridge = await bridgeFactory.deploy(
       await mockXEUR.getAddress(),
@@ -99,12 +99,19 @@ describe("Native Challenge Tests", () => {
 
     await evm_increaseTime(60);
 
+    // Alice gets a larger initial allocation so the "buy ALL" test path is
+    // affordable under EXPIRED_PRICE_FLOOR_PPM (which keeps the late-phase
+    // force-sale price above zero).
     const mintAmount = floatToDec18(200_000);
-    for (const signer of [owner, alice, bob, charles]) {
+    const aliceMintAmount = floatToDec18(2_000_000);
+    for (const signer of [owner, bob, charles]) {
       await mockXEUR.mint(signer.address, mintAmount);
       await mockXEUR.connect(signer).approve(await bridge.getAddress(), mintAmount);
       await bridge.connect(signer).mint(mintAmount);
     }
+    await mockXEUR.mint(alice.address, aliceMintAmount);
+    await mockXEUR.connect(alice).approve(await bridge.getAddress(), aliceMintAmount);
+    await bridge.connect(alice).mint(aliceMintAmount);
 
     // VOL tokens for non-WETH tests
     mockVOL = await testTokenFactory.deploy("Volatile Token", "VOL", 18);


### PR DESCRIPTION
## Summary

Tightens two parameter bounds in `MintingHubV3`:

- `Position.initialize()` requires the inherited expiration to leave at least `2 * challengePeriod` of remaining lifetime on a clone, in line with the documented intent that clones are positions with a meaningful active period.
- `MintingHub.expiredPurchasePrice()` introduces a floor at `EXPIRED_PRICE_FLOOR_PPM = 300_000` (30% of the liquidation price) on the late-phase decay curve.

Both are conservative invariant tightenings; they do not change the position lifecycle or the force-sale flow otherwise.

## Files

| File | +/− |
| --- | ---: |
| `contracts/MintingHubV3/Position.sol` | +25 / −7 |
| `contracts/MintingHubV3/MintingHub.sol` | +73 / −20 |
| `test/unit/ForceSaleTests.ts` | +112 / −3 |
| `test/unit/NativeChallengeTests.ts` | +10 / −1 |

## Test plan

- [x] Full unit suite passes (`npx hardhat test test/unit/*.ts`)
- [x] Solidity prettier clean
- [ ] External review of the chosen bounds before deployment

## Deployment

These are non-upgradable contracts. Rollout requires deploying a fresh `MintingHub` / `Position` implementation pair and registering the new `MintingHub` via `DecentralizedEURO.suggestMinter()` with the `MIN_APPLICATION_PERIOD` veto window. Frontend routing switches over after approval. Out of scope for this PR.